### PR TITLE
update docs to reflect more possible regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ climate:
    - platform: fglair_heatpump_controller
      username: <your FGLair username>
      password: <your FGLair password> 
-     region: [eu, cn, us] (optional, default: us)
+     region: ['eu' | 'cn' | 'us' | 'ca' | 'au' | '`your country code`'] (optional, default: 'us')
      tokenpath: (optional, default: 'token.txt')       
 ```
 


### PR DESCRIPTION
This PR updates the `README` to reflect that there are more possible values to `region` than `us`, `cn` and `eu`. It also clarifies that it needs to be wrapped in single quotes.